### PR TITLE
Improving light theme image contrast

### DIFF
--- a/OtterDen/otter_den/templates/about.html
+++ b/OtterDen/otter_den/templates/about.html
@@ -3,7 +3,13 @@
 {% extends "layout.html" %}
 {% block content %}
     <center>
-        <img class="img mt-2 mb-5" id="logo" src="/static/logo.png" width=500 height=193>
+        <img 
+            class="img mt-2 mb-5" 
+            id="logo" 
+            src="{{ '/static/logo.png' if session.get('theme') == 'dark' else '/static/logo-light.png' }}"
+            width=500 
+            height=193 
+        >
         <h1>About The Otter Den</h1>
         This blog was created by ByteOtter. Give me a visit under www.github.com/ByteOtter.
         


### PR DESCRIPTION
# What does this PR change?

Currently, the image in the about page is hard to see when the light theme is selected. Now, the image on the about page will change to a dark variant when the light theme is selected.

Tick the applicable box:
- [ ] Add new feature
- [X] UI improvement
- [ ] Changed routing
- [ ] Security changes
- [ ] Testsuite
<br/>

- [ ] General Maintenance

Fixes #64 
