### PR TITLE
Add navigational dropdown

### DIFF
--- a/OtterDen/otter_den/static/main.css
+++ b/OtterDen/otter_den/static/main.css
@@ -78,6 +78,20 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 500;
 }
 
+.dropdown:hover .dropdown-menu {
+  background-color: var(--site-header-color);
+  display: block;
+  margin-top: 0;
+}
+
+.dropdown-item {
+  color: var(--navbar-text-color);
+}
+
+.dropdown-divider {
+  color: var(--article-content-color);
+}
+
 .content-section {
   /* color: var(--article-content-color);*/
   background: var(--background-color);

--- a/OtterDen/otter_den/static/main.css
+++ b/OtterDen/otter_den/static/main.css
@@ -101,6 +101,17 @@ h1, h2, h3, h4, h5, h6 {
   margin-bottom: 20px;
 }
 
+.danger-text {
+  margin-left: 2px;
+  color: #ff0000;
+}
+
+.danger-text-box {
+  padding-bottom: 1px;
+  margin-bottom: 4px;
+  border: 2px #ff0000 dashed;
+}
+
 .account-heading {
   font-size: 2.5rem;
 }

--- a/OtterDen/otter_den/templates/account.html
+++ b/OtterDen/otter_den/templates/account.html
@@ -64,14 +64,30 @@
                         {% endfor %}
                     {% endif %}
                 </div>
+                <!-- PRIVACY OPTIONS! -->
+                <h5>Your privacy is important - protect it!</h5>
+                <div class="form check form-switch" id="hideMailAdressSwitch">
+                    <input class="form-check-input" type="checkbox" role="switch" id="hideMailAdress" checked>
+                    <label class="form-check-label" for="fkexSwitchCheckChecked">Hide my e-mail adress
+                        <text class="text-secondary">(default: on)</text>
+                    </label>
+                </div>
+                <div class="form check form-switch" id="hideMailAdressSwitch">
+                    <input class="form-check-input" type="checkbox" role="switch" id="hideMailAdress" unchecked>
+                    <label class="form-check-label" for="fkexSwitchCheckChecked">Keep my posts private. <text class="text-secondary">(default: off)
+                        <br>Logged in users can still see you posts.</text>
+                    </label>
+                </div>
             </fieldset>
             <div class = "form-group">
                 <a class="btn btn-secondary" href="{{ url_for('main.home') }}">Cancel</a>
                 {{ form.submit(class = "btn btn-info") }}
             </div>
         </form>
-        <div class = "article-metadata text-secondary mt-2">Danger Zone!</div>
-        <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" data-target="#deleteModal">Delete Profile</button>
+        <div class = "danger-text-box mt-2">
+            <h6 class="danger-text mt-2 ml-1">Danger Zone!</h6>
+            <button type="button" class="btn btn-danger btn-sm ml-1 mb-2" data-toggle="modal" data-target="#deleteModal">Delete Profile</button>
+        </div>
     </div>
     <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
@@ -84,7 +100,6 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <!--it can't grab the username for some reason-->
           <form action="{{ url_for('users.delete_user', username=username) }}" method="POST">
             <input class="btn btn-danger" type="submit" value="Delete">
           </form>

--- a/OtterDen/otter_den/templates/home.html
+++ b/OtterDen/otter_den/templates/home.html
@@ -1,4 +1,4 @@
-<!--Copyright ByteOtter (c) 2021-2022-->
+<!--Copyright ByteOtter (c) 2021-2023-->
 
 {% extends "layout.html" %}
 {% block content %}

--- a/OtterDen/otter_den/templates/layout.html
+++ b/OtterDen/otter_den/templates/layout.html
@@ -1,4 +1,4 @@
-<!--Copyright ByteOtter (c) 2021-2022-->
+<!--Copyright ByteOtter (c) 2021-2023-->
 
 <!DOCTYPE html>
 <html lang="en" class="{{ 'dark-mode' if session.get('theme') == 'dark' }}">

--- a/OtterDen/otter_den/templates/layout.html
+++ b/OtterDen/otter_den/templates/layout.html
@@ -55,20 +55,35 @@
                                 </svg>
                                 Create new post!
                             </a>
-                            <a class="nav-item nav-link" href="{{ url_for('users.account') }}">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
-                                    <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"/>
-                                    <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z"/>
-                                </svg>
-                                {{current_user.username}}
-                            </a>
-                            <a class="nav-item nav-link" href="{{ url_for('users.logout') }}">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-door-open" viewBox="0 0 16 16">
-                                    <path d="M8.5 10c-.276 0-.5-.448-.5-1s.224-1 .5-1 .5.448.5 1-.224 1-.5 1z"/>
-                                    <path d="M10.828.122A.5.5 0 0 1 11 .5V1h.5A1.5 1.5 0 0 1 13 2.5V15h1.5a.5.5 0 0 1 0 1h-13a.5.5 0 0 1 0-1H3V1.5a.5.5 0 0 1 .43-.495l7-1a.5.5 0 0 1 .398.117zM11.5 2H11v13h1V2.5a.5.5 0 0 0-.5-.5zM4 1.934V15h6V1.077l-6 .857z"/>
-                                </svg>
-                                Logout
-                            </a>
+                            <!-- Navigational dropdown for easy navigation. At most 5 points! -->
+                            <div class="dropdown">
+                                <a class="nav-item nav-link dropdown-toggle" href="{{ url_for('users.user_profile', username=current_user.username) }}" type="button" id="userDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <img class="rounded-circle" src="{{ url_for('static', filename='profile_pictures/' + current_user.image_file) }}" width="20" height="20" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16"></img>
+                                    {{ current_user.username }}
+                                </a>
+                                <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                    <a class="dropdown-item" href="{{ url_for('users.show_user_post_history', username=current_user.username) }}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-book-half" viewBox="0 0 16 16">
+                                            <path d="M8.5 2.687c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"/>
+                                        </svg>
+                                        My Posts
+                                    </a>
+                                    <a class="dropdown-item" href="{{ url_for('users.account') }}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-gear-fill" viewBox="0 0 16 16">
+                                            <path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z"/>
+                                        </svg>
+                                        Settings
+                                    </a>
+                                    <div class="dropdown-divider"></div>
+                                    <a class="dropdown-item" href="{{ url_for('users.logout') }}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-door-open" viewBox="0 0 16 16">
+                                            <path d="M8.5 10c-.276 0-.5-.448-.5-1s.224-1 .5-1 .5.448.5 1-.224 1-.5 1z"/>
+                                            <path d="M10.828.122A.5.5 0 0 1 11 .5V1h.5A1.5 1.5 0 0 1 13 2.5V15h1.5a.5.5 0 0 1 0 1h-13a.5.5 0 0 1 0-1H3V1.5a.5.5 0 0 1 .43-.495l7-1a.5.5 0 0 1 .398.117zM11.5 2H11v13h1V2.5a.5.5 0 0 0-.5-.5zM4 1.934V15h6V1.077l-6 .857z"/>
+                                        </svg>
+                                        Logout
+                                    </a>
+                                </div>
+                            </div>
                         {% else %}
                             <a class="nav-item nav-link" href="{{ url_for('users.login') }}">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-door-open" viewBox="0 0 16 16">


### PR DESCRIPTION
# What does this PR change?

This PR lays the ground work for a dedicated account settings page based on the `account.html` page.

TODO:

- [x] Create dropdown menu with hover toggle and links to the future `settings` page aswell as `post history` and `logout`
- [x] Expand `account.html` with toggle switches for privacy options (e.g hiding mail adress)

Tick the applicable box:
- [x] Add new feature
- [x] UI improvement
- [x] Changed routing
- [ ] Security changes
- [ ] Testsuite
<br/>

- [ ] General Maintenance

## UI changes

provide description here or remove all unapplicable lines below

before:
Righthand side of navbar consisted of a logout link and a link to the `account.html` page

after:
Now on the right end of the navbar, the Username hides a dropdown menu which is opened by hovering over it and links to `post_history.html`, `account.html` and `logout`

 - [x] DONE

## Links

In case your changes fix an existing issue please link it below:

Tracks #52 

- [x] DONE

## Documentation

provide description about documentation done here or remove this line

- No documentation needed
<br/>

- [x] DONE
